### PR TITLE
Personalised container graders example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: '3'
 services:
   grader:
     image: apluslms/run-mooc-grader
+    entrypoint: >
+      bash -c "python3 manage.py pregenerate_exercises default;
+               python3 manage.py runserver 0.0.0.0:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/srv/courses/default

--- a/index.yaml
+++ b/index.yaml
@@ -36,6 +36,9 @@ modules:
       - key: hello_scala
         config: hello_scala/config.yaml
         type: prg
+      - key: personalized_number
+        config: personalized_number/config.yaml
+        type: prg
 
   - key: chapter
     name: Sample chapters

--- a/personalized_number/check_number.py
+++ b/personalized_number/check_number.py
@@ -1,0 +1,22 @@
+try:
+    # Note! User can tamper with the value and so cheat. Needs a fix in
+    # mooc-grader.
+    with open('number') as orig_file:
+        start = int(orig_file.read().strip())
+    with open('solution') as submitted_file:
+        solution = int(submitted_file.read().strip())
+
+    max_points = 10
+    points = 0
+    if solution == (start + 1):
+        points = max_points
+
+    print("TotalPoints: {}".format(points))
+    print("MaxPoints: {}".format(max_points))
+
+    print("Original number was: {}".format(start))
+    print("Your solution was: {}".format(solution))
+
+except Exception:
+    print("ERROR")
+    raise

--- a/personalized_number/config.yaml
+++ b/personalized_number/config.yaml
@@ -1,0 +1,35 @@
+---
+title: Personalized number
+max_points: 10
+instructions: |
+  <h1>Personalized number</h1>
+  <p>
+    Your personalized exercise is a number. You must submit the number
+    incremented by one.
+  </p>
+view_type: access.types.stdasync.acceptPost
+fields:
+  - name: solution
+    title: Solution
+    required: True
+  - name: number
+    title: Number
+    required: True
+
+template: default/personalized_number/template.html
+
+personalized: True
+generated_files:
+  - file: number
+    key: number
+    content_in_template: True
+    url_in_template: True
+    allow_download: True
+generator:
+  cmd: [ "python3", "generator.py" ]
+  cwd: default/personalized_number/
+
+container:
+  image: apluslms/grading-python:3.5
+  mount: personalized_number
+  cmd: /exercise/run.sh

--- a/personalized_number/generator.py
+++ b/personalized_number/generator.py
@@ -1,0 +1,8 @@
+import sys
+import os
+import random
+
+instance_dir = sys.argv[1]
+number = random.randint(1, 50)
+with open(os.path.join(instance_dir, "number"), "w") as f:
+    f.write(str(number))

--- a/personalized_number/run.sh
+++ b/personalized_number/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# The uploaded user files are always in /submission/user
+# and named identically to config.yaml regardless of the uploaded file names.
+cd /submission/user
+
+# The mount directory from config.yaml is in /exercise.
+# Append the required support files to test user solution.
+cp /exercise/*.py .
+
+# "capture" etc description in https://github.com/A-plus-LMS/grading-base
+
+capture python3 check_number.py
+
+err-to-out
+grade

--- a/personalized_number/template.html
+++ b/personalized_number/template.html
@@ -1,0 +1,17 @@
+{% extends 'access/exercise_frame.html' %}
+{% load i18n %}
+
+{% block exercise %}
+
+Your number: {{ generated_files.number.content }}.
+
+<form method="post" action="{{ post_url }}">
+  Solution:<br>
+  <input type="text" name="solution">
+  <input type="hidden" name="number" value="{{ generated_files.number.content }}">
+  <div class="form-group">
+    <input type="submit" value="{% trans 'Submit' %}" class="btn btn-primary aplus-submit" />
+  </div>
+</form>
+
+{% endblock %}


### PR DESCRIPTION
This pull requests proposes one way of implementing personalised exercises for the container graders. It is based on the personalized_number example from the old templates. I couldn't attend the second part of the A+CON where the personalisation may have been discussed. Is there a better way to implement personalised exercises for container graders?

This solution passes the generated file contents as hidden values in a custom form template. The biggest problem is that the students may tamper with the hidden form values. Would it be better to implement a mechanism in mooc-grader to copy the personalised files to the submission directory passed to the container?

Other changes I made was to pregenerate the personalised content on each `docker-compose up`. Perhaps that change would be better in https://github.com/A-plus-LMS/run-mooc-grader?