### PR TITLE
Fix turtle python exercise

### DIFF
--- a/exercises/turtle_python/config.yaml
+++ b/exercises/turtle_python/config.yaml
@@ -7,6 +7,6 @@ files:
     name: turtles.py
 
 container:
-  image: apluslms/grade-python:math-latest
+  image: apluslms/grade-python:3.7-3.2.3-3.0
   mount: exercises/turtle_python
   cmd: /exercise/run.sh

--- a/exercises/turtle_python/grader_tests.py
+++ b/exercises/turtle_python/grader_tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+from graderutils.graderunittest import points
 import sys
 import os
 import random
@@ -11,9 +12,9 @@ import simpleturtle
 from minipng import Image
 
 class TestTurtle(unittest.TestCase):
-
+    @points(40)
     def test1_get_direction(self):
-        """Function get_direction returns string 'right' or 'left' according to specification. (1p)"""
+        """Function get_direction returns string 'right' or 'left' according to specification."""
         count = 200
         for _ in range(count):
             n = random.randint(1, 4096)
@@ -26,12 +27,15 @@ class TestTurtle(unittest.TestCase):
                 .format(n, returned_answer, expected_answer)
             )
 
-    def test2_run_turtles_with_image(self):
-        """Function turtles draws the picture without error messages. (1p)"""
+    @points(60)
+    def test1_2_run_turtles_with_image(self):
+        """Function turtles draws the picture without error messages."""
         t = simpleturtle.Turtle()
         turtles.turtles(t)
 
         t.get_image().write_to_file('turtles.png.base64', 'base64')
+
+
 
 if __name__ in ("__main__", "tests"):
     from sys import version_info

--- a/exercises/turtle_python/test_config.yaml
+++ b/exercises/turtle_python/test_config.yaml
@@ -1,12 +1,14 @@
-test_modules:
+test_groups:
   - module: grader_tests
     description: Grader tests
 
 feedback_template: feedback_plot_png.html
 
 validation:
-  - type: python_import
-    file: turtles.py
+    display_name: Input validation
+    tasks:
+        - type: python_import
+          file: turtles.py
+        - type: python_syntax
+          file: turtles.py
 
-  - type: python_syntax
-    file: turtles.py


### PR DESCRIPTION
# Description

* The [test_config.yam](https://github.com/apluslms/course-templates/blob/master/exercises/turtle_python/test_config.yam) file was using an old syntax, and it needed to be updated.
* The `image` parameter was update in the file [config.yaml](https://github.com/apluslms/course-templates/blob/master/exercises/turtle_python/config.yaml). It was changed from `image: apluslms/grade-python:math-latest` to `image: apluslms/grade-python:3.7-3.2.3-3.0`
* The decorator `@points(#)` was added to the  [grader_test.py](https://github.com/apluslms/course-templates/blob/master/exercises/turtle_python/grader_tests.py) file. 

Check [python-grader-utils](https://github.com/Aalto-LeTech/python-grader-utils/tree/v3.2.3) for more information about the new sintax.

# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [X] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [X] Not relevant
