### PR TITLE
Remove the actions parameter from /exercises/personalized*/config.yaml

### DIFF
--- a/exercises/personalized_number/config.yaml
+++ b/exercises/personalized_number/config.yaml
@@ -33,14 +33,3 @@ container:
   image: apluslms/grade-python:3.6-2.7
   mount: exercises/personalized_number
   cmd: /exercise/run.sh
-
-# old chroot sandbox configuration. This is an alternative to the Docker
-# container grader.
-actions:
-  - type: grader.actions.prepare
-    expect_success: True
-    cp_generated: number->user/number
-    cp_exercises: exercises/personalized_number->user
-  - title: Check solution
-    type: grader.actions.sandbox
-    cmd: [ "python3", "check_number.py" ]

--- a/exercises/personalized_python/config.yaml
+++ b/exercises/personalized_python/config.yaml
@@ -31,17 +31,3 @@ container:
   image: apluslms/grade-python:3.6-2.7
   mount: exercises/personalized_python
   cmd: /exercise/run.sh
-
-# old chroot grading sandbox configuration
-actions:
-  - type: grader.actions.prepare
-    expect_success: True
-    cp_generated: name->user/name
-    cp_exercises: exercises/personalized_python->user
-  - title: Check solution
-    type: grader.actions.sandbox
-    cmd: [ "python3", "check.py" ]
-    files: 4
-    # file descriptor limit can not be set to zero since the grader
-    # must read a file itself, but then it does not prevent the student's
-    # submission from reading files either


### PR DESCRIPTION
The `actions` parameter is no longer supported by the mooc-grader.
Therefore, it should be removed from the config.yaml files.

# Description


# Testing

- [ ] I created new unit tests
- [ ] All unit tests pass
- [X] I have tested manually

# Have you updated the README or other relevant documentation?

- [ ] Yes
- [ ] Not yet. I will do it next.
- [X] Not relevant
