### PR TITLE
Updates to docker-up.sh including fix to script not stopping

### DIFF
--- a/docker-up.sh
+++ b/docker-up.sh
@@ -41,7 +41,8 @@ pid=
 keep=
 onexit() {
     trap - INT
-    [ "$pid" ] && kill $pid || true
+    # send SIGINT (^C) to childs of the docker-compose and to the process itself
+    [ "$pid" ] && { pkill -2 -P $pid; kill -2 $pid; } || true
     wait
     if [ "$keep" = "" ]; then
         clean

--- a/docker-up.sh
+++ b/docker-up.sh
@@ -118,6 +118,9 @@ while kill -0 $pid 2>/dev/null; do
 
     # print status and help
     echo
+    echo "  List of alive containers:"
+    { docker container ls --filter "name=^${COMPOSE_PROJECT_NAME}_"  --format "{{.ID}}" | xargs docker container inspect --format '	{{.Name}}	{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}	{{range $p, $conf := .NetworkSettings.Ports}}{{$p}} {{end}}'; } 2>/dev/null || true
+    echo
     echo "  Press Q or ^C to stop all and to remove data"
     echo "  Press S or ESC to stop all and to keep data"
     echo

--- a/docker-up.sh
+++ b/docker-up.sh
@@ -55,7 +55,7 @@ onexit() {
 
 clean() {
     echo " !! Removing persistent data !! "
-    docker-compose down --volumes
+    docker-compose down --volumes --remove-orphans
     if [ "$DATA_PATH" -a -e "$DATA_PATH" ]; then
         echo "Removing $DATA_PATH"
         rm -rf "$DATA_PATH" || true

--- a/docker-up.sh
+++ b/docker-up.sh
@@ -50,6 +50,7 @@ onexit() {
         echo "Data was not removed. You can remove it with: $0 --clean"
     fi
     rm -rf /tmp/aplus || true
+    while read -rs -t 0; do read -rs -t 0.1; done # flush input
     exit 0
 }
 
@@ -87,25 +88,38 @@ while [ "$1" ]; do
     shift
 done
 
+docker-compose --version
 
 if [ $(($(date +%s) - $(date -r docker-compose.yml +%s))) -gt 604800 ]; then
     # pull updates weekly
+    echo "Checking for updates to the service images..."
     update
+    echo
 fi
 
 mkdir -p /tmp/aplus
 trap onexit INT
 docker-compose up & pid=$!
 
+help_n=4 # show first info after 24 seconds
 while kill -0 $pid 2>/dev/null; do
-    echo "  Press Q or ^C to quit and remove data"
-    echo "  Press S or ESC to quit and keep data"
-    read -rsn1 i
-    if [ "$i" = 'q' -o "$i" = 'Q' ]; then
-        break
-    elif [ "$i" = 's' -o "$i" = 'S' -o "$i" = $'\e' ]; then
-        keep="x"
-        break
-    fi
+    while read -rs -t 0; do read -rs -t 0.1; done # flush input
+    read -rsn1 -t 6 i # read a byte
+    # (1 or 142) -> timeout (6s). Show help every 50 times (every 5 minutes)
+    [[ $? != 0 ]] && { ((--help_n > 0)) && continue || help_n=50; }
+    case "$i" in
+        q|Q) break ;;
+        s|S) keep="x" ; break ;;
+        $'\e') # escape (ESC or ANSI code)
+            read -rsn1 -t 0.01 i # try to read a second byte
+            [ $? -eq 142 ] && { keep="x"; break; } # timeout -> no second byte -> plain ESC
+            ;;
+    esac
+
+    # print status and help
+    echo
+    echo "  Press Q or ^C to stop all and to remove data"
+    echo "  Press S or ESC to stop all and to keep data"
+    echo
 done
 onexit


### PR DESCRIPTION
# Description

Docker-compose spawns two processes. The parent of those ignores all signals, thus the signal must be send to the child process. See https://github.com/docker/compose/issues/6874 . This PR includes a workaround for that.

In addition, rewrote the reading of keypresses, which now handles escape sequences (e.g. up arrow and page up). Pressing ESC once still works.

Furthermore, the help text is printed 30 seconds after start and every 5 minutes. This lists the possible keys and also ip addresses of the containers (they are sometimes needed, specially by me).

# Testing

- [x] Tested with Ubuntu 18.04 (Aalto Ubuntu, bash 4.4.20(1)-release, docker-compose 1.26.0, build d4451659)
- [x] Tested with Debian testing (bash 5.0.16(1)-release, docker-compose 1.25.5, build 8a1c60f6)
- [x] Tested with Debian testing (bash 5.0.16(1)-release, docker-compose 1.26.2, build eefe0d31)
- [x] Tested with macOS (bash 3.2.57(1)-release, docker-compose 1.25.5, build 8a1c60f6)

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly