### PR TITLE
Add Rubyric exercises, details about the configuration of the exercises and instructions about local development

### DIFF
--- a/exercises/hello_rubyric/config.yaml
+++ b/exercises/hello_rubyric/config.yaml
@@ -1,0 +1,12 @@
+_external: true
+title: Hello Rubyric
+description: Submit a text file (.txt) with the contain "Hello Rubyric"
+max_submissions: 10
+max_points: 10
+points_to_pass: 6
+min_group_size: 1
+max_group_size: 2
+lti: Rubyric
+lti_aplus_get_and_post: true
+url: /aplus_exercise
+

--- a/rubyric/02_getting_started.rst
+++ b/rubyric/02_getting_started.rst
@@ -24,6 +24,24 @@ a new menu item in A+ choose Edit course and Menu and press Add new menu item.
 You can also choose to use Rubyric through Haka login. In that case you don't
 need to add Rubyric to menu.
 
+Set up Rubyric locally
+----------------------
+
+If you want to test Rubyric locally, you must follow the instructions on how
+to set up a Rubyric locally along with A+, presented in the `Official Rubyric
+documentation. <https://github.com/Aalto-LeTech/rubyric/blob/master/doc/rubyric.md#
+connect-local-rubyric-to-a-course-in-docker-optional>`_
+It is also worth mentioning that currently setting up Rubyric locally can be
+slightly difficult, and there may be some problems that will require you to
+solve some dependency issues. Therefore, we recommend reading the
+`Troubleshooting section <https://github.com/Aalto-LeTech/rubyric#troubleshooting>`_
+when setting up Rubyric on your computer.
+
+But, if you do not want to spend too much time setting up Rubyric locally, you
+could also test the Rubyric directly in a testing server, e.g.
+https://minus.cs.aalto.fi for the Aalto CS department, and verify that the
+exercises connect to Rubyric.
+
 Configure course at Rubyric
 ---------------------------
 

--- a/rubyric/02_getting_started.rst
+++ b/rubyric/02_getting_started.rst
@@ -63,25 +63,25 @@ To create a new course and course instance follow these steps:
 2. Press "Create new course" button at frontpage or go to `https://rubyric.cs.hut.fi/course_instances/new <https://rubyric.cs.hut.fi/course_instances/new>`_
 3. Fill in the form and click "Create"
 
-"Create new course" button is not visible if you have previously only used 
-Rubyric as a student or as an assistant. If this is the case you need to use the 
+"Create new course" button is not visible if you have previously only used
+Rubyric as a student or as an assistant. If this is the case you need to use the
 link to access the create course form.
 
-The form asks for Course name, Course instance name, Interface language 
-and Submission policy. Interface language affects on the language some 
-instructions are shown to course instructions and assistants. 
+The form asks for Course name, Course instance name, Interface language
+and Submission policy. Interface language affects on the language some
+instructions are shown to course instructions and assistants.
 
 Submission policy defines who are allowed to submit to assignments:
 
-- "Anybody can submit without authentication" allows students to submit without 
+- "Anybody can submit without authentication" allows students to submit without
   logging in after providing their email address. This can be useful on MOOCs.
 - "Any authenticated user can submit" requires students to login before allowing
   them to submit.
-- "Only enrolled students can submit" requires the instructor to provide list of 
+- "Only enrolled students can submit" requires the instructor to provide list of
   students who are allowed to submit.
 - "LTI integration" is used in LTI and A+ connected courses. If you wish to
   connect the course to A+, choose this option.
-  
+
 To configure A+ connected course you have two choices.
 
 (Recommended) The first option:
@@ -90,26 +90,26 @@ To configure A+ connected course you have two choices.
 
    - If the course has not yet been configured at Rubyric, you will
      be redirected to create course form
-     
+
 2. Fill in the course and course instance names and click "Create"
 
-   - The form already has LTI consumer ID and LTI context ID filled in, 
-     do not touch them. 
-    
+   - The form already has LTI consumer ID and LTI context ID filled in,
+     do not touch them.
+
 The second option:
 
 1. Login to Rubyric
 2. Press "Create new course" button at frontpage or go to `https://rubyric.cs.hut.fi/course_instances/new <https://rubyric.cs.hut.fi/course_instances/new>`_
-3. Fill in the course and course instance names and choose "LTI integration" as 
+3. Fill in the course and course instance names and choose "LTI integration" as
    Submission policy
 4. Fill in the LTI consumer ID and LTI context ID and click "Create"
 
    - Click the Rubyric menu item at A+
    - Click "Show details" and fill the form at Rubyric with values from details (see the image)
-   
+
      - LTI consumer ID: ``oauth_consumer_key``
      - LTI context ID: ``context_id``
-    
+
 If you are redirected straight to Rubyric instead of having chance to
 choose "Show details", or you do not want to include the LTI login,
 you can try using ``plus.cs`` as LTI consumer ID and the address of your course
@@ -120,7 +120,7 @@ you can try using ``plus.cs`` as LTI consumer ID and the address of your course
 
 To create a new course instance to existing course, navigate to course by
 clicking its name on the front page and click on "Create new course instance".
-If you want to connect a new course instance to A+ follow the second option's 
+If you want to connect a new course instance to A+ follow the second option's
 instructions to fetch the LTI consumer ID and LTI context ID values.
 
 .. warning::
@@ -165,42 +165,56 @@ Review mode affects on what kind of reviews will be done. More about reviews on
 to send reviews immediately", reviewers are allowed to send reviews back to
 students right after finishing review. Otherwise instructors will have to
 send reviews afterwards. Crossing "Allow reviewers to review all submissions"
-allows reviewers to view and review any submission in the exercise. Otherwise 
-reviewers are only allowed to review submissions from groups assigned to them. 
-Rubyric also allows students to conduct peer reviews. If peer review count is 
-left empty, no peer review is expected. On the other hand collaborative mode 
-allows students to construct feedback for each other but they are not required 
+allows reviewers to view and review any submission in the exercise. Otherwise
+reviewers are only allowed to review submissions from groups assigned to them.
+Rubyric also allows students to conduct peer reviews. If peer review count is
+left empty, no peer review is expected. On the other hand collaborative mode
+allows students to construct feedback for each other but they are not required
 to review other people's submissions.
 
 Check out the chapter `LTI configuration in A+ <../m05_lti/configuration>`_
-to find out how to configure an LTI exercise in A+. After configuring the 
-exercise at A+ you still need to configure it at Rubyric. It can be done 
+to find out how to configure an LTI exercise in A+. After configuring the
+exercise at A+ you still need to configure it at Rubyric. It can be done
 automatically or manually.
 
 Automatic exercise configuration through A+:
 
-1. Create a new A+ exercise using Rubyric as LTI service, use:
+1. Create a new A+ exercise using Rubyric as LTI service. The following snippet
+   shows the code used in the :ref:`First example <rubyric-exercise>` presented
+   in the :doc:`example section <example>`. As you can see, the ``:lti: Rubyric``
+   value is required to identify the service that is  going to be used, the
+   ``:lti_aplus_get_and_post:`` must be added to connect to Rubyric since Rubyric
+   since Rubyric does not support LTI, finally, the ``:url: /aplus_exercise`` is
+   specific to Rubyric and it makes Rubyric create the exercise automatically so
+   that the teacher does not need to manually create any exercises in Rubyric
+   beforehand. If the exercises are created beforehand, then the URL must
+   hard code the id value.
 
-   - Service url: /aplus_exercise
-   - Aplus get and post: True
-   - Open in iframe: True
-   
+   .. code-block:: rst
+     :caption: Rubyric submit directive
+
+     .. submit:: rubyric_example 10
+       :title: Rubyric example
+       :lti: Rubyric
+       :lti_aplus_get_and_post:
+       :url: /aplus_exercise
+
 2. Open the exercise at A+
 
    - Opening the exercise configures it at Rubyric if it has not yet been done
-   
+
 3. (Optional) Login to Rubyric and change exercise settings to your liking
 
    - Do not touch LTI resource link ID
-   
+
 To configure the exercise manually you need to set LTI resource link ID at
-Rubyric to be same as it is in A+ exercise. You don't have to fill in 
-LTI resource link ID for peer review and LTI resource link ID for viewing 
-feedback unless you want to use Rubyric's peer review or want students to view 
+Rubyric to be same as it is in A+ exercise. You don't have to fill in
+LTI resource link ID for peer review and LTI resource link ID for viewing
+feedback unless you want to use Rubyric's peer review or want students to view
 the feedback at Rubyric. You need to set Service url at A+ to service url shown
 at exercise page at Rubyric after you have created the Rubyric exercise.
 
-The configuration has been successful if you can see the submit button when 
+The configuration has been successful if you can see the submit button when
 opening the exercise at A+.
 
 .. image:: /images/rubyric-create-assignment.png

--- a/rubyric/example.rst
+++ b/rubyric/example.rst
@@ -1,8 +1,24 @@
 Example Rubyric exercise
 ========================
 
+The following examples will allow you to submit a test exercise. However, these
+exercises will not be reviewed by the A+ team, and you won't get a grade. The
+only intention of having these test exercises heres is to show you how the UI of
+the Rubyric exercises looks like, and how the settings added in the RST
+directives affect the actual Rubyric exercise.
+
+Worth mentioning that the first exercise was set up using only RST, while the
+second exercises was set up using a **config.yaml** file. As you can
+see both exercises work just fine. However, we **STRONGLY** recommend setting up
+your exercises using RST, and avoid the use of the **config.yaml** file.
+
+.. _rubyric-exercise:
+
 .. submit:: rubyric_example 10
   :title: Rubyric example
   :lti: Rubyric
   :lti_aplus_get_and_post:
   :url: /aplus_exercise
+
+.. submit:: rubyric 10
+  :config: exercises/hello_rubyric/config.yaml


### PR DESCRIPTION
# Description

Instructions about testing Rubyric in a local environment is added.
In addition, one more Rubyric exercise is added to the manual along
with some detail about some of the configuration parameters.

# Testing

I tested the exercises in http://localhost:8000/def/current/rubyric/example/

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

*Clean up your git commit history before submitting the pull request!*

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
