### PR TITLE
Add .editorconfig and docker-fast-compile.sh

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,77 @@
+
+# EditorConfig: https://EditorConfig.org
+# Some editors require a plugin. Check the above site for details!
+
+# List of fully and partially supported properties:
+#  https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+
+# NOTE: this file is shared among multiple projects. If neccessary, please
+# update the upstream file acordingly!
+# https://github.com/apluslms/apluslms.github.io/blob/master/.editorconfig.
+
+# More information about the current style followed in the apluslms projects
+# can be found on https://apluslms.github.io/contribute/styleguides/.
+
+# You may copy this file and add local changes at the bottom.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile*]
+indent_style = tab
+indent_size = 8
+
+# data
+
+[*.{json,yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# markup
+
+[*.html]
+indent_style = tab
+
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false
+
+[*.rst]
+indent_style = space
+indent_size = 2
+max_line_length = 120
+
+# styling
+
+[*.{css,scss,sass}]
+indent_style = tab
+
+# programming
+
+[*.js]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+# Docstrings and comments use max_line_length = 79
+max_line_length = 119
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+# overrides
+
+[*.min.{js,css}]
+indent_style = unset
+insert_final_newline = unset
+trim_trailing_whitespace = false
+
+# Non-global changes for a particular project should be added below this line

--- a/docker-fast-compile.sh
+++ b/docker-fast-compile.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+docker run --rm \
+  -v "$(pwd):/compile" \
+  -u $(id -u):$(id -g) \
+  -e "STATIC_CONTENT_HOST=http://localhost:8080/static/default" \
+  -e "COURSE_KEY=default" \
+  apluslms/compile-rst:1.6 \
+  make html


### PR DESCRIPTION
# Description

* **.editorconfig**: It is used to help maintain some consistency in the  coding style
* **docker-fast-compile.sh**: It is used to reduce the compilation time of any course. Basically, the docker-fast-compile.sh does not force a complete compilation of all files. Therefore, it is still recommended to run the docker-compile.sh script for the testing phase, before publishing the course in A+ (plus.cs.aalto.fi).

# Testing

The **.editorconfig** was tested in vim and VS Code.

The **docker-fast-compile.sh** was tested in the integrated terminal of VS Code and in a ubuntu terminal.

# Have you updated the README or other relevant documentation?

We will need to add some description of the docker-fast-compile.sh in the course manual. Nonetheless, a description of these two new files was added in the new https://github.com/apluslms/aplus-course-template, which may be enough.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [X] I (developer) have tested the changes manually
- [X] Reviewer has finished the code review
- [X] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
