### PR TITLE
Fix inconsistency in decorator description

### DIFF
--- a/programming_exercises/hello_world.rst
+++ b/programming_exercises/hello_world.rst
@@ -199,7 +199,7 @@ The following steps are executed inside the grade-python container.
 
 17. Because ``test_function`` has the docstring
     ``"""Check hello function exists"""``, Graderutils will show this
-    as the title of the test. The decorator ``@points(1)`` grants five points
+    as the title of the test. The decorator ``@points(1)`` grants one point
     if the test passes. Similarly, ``test_import`` also
     yields one point if it passes and ``test_return`` will yield three points if
     it passes.


### PR DESCRIPTION
# Description

In "Hello Python: grading steps in detail" section, step 17, the decorator ``@points(1)`` is said to give 5 points, which it should presumably be said to give just 1 point. I edited the corresponding .rst file to reflect this.

**Why?**

To prevent confusion about how the ``@points(n)`` decorator works.

**How?**

Replaced "five points" with "one point" in the .rst file containing the corresponding material.


# Testing

No testing was carried out.

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [ ] Manual testing.

**Did you test the changes in**

- [ ] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

**Think of what is affected by these changes and could become broken**

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [ ] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature

*Clean up your git commit history before submitting the pull request!*
